### PR TITLE
Additional fix for issue #26

### DIFF
--- a/TinyOPDS/OPDS/NewBooksCatalog.cs
+++ b/TinyOPDS/OPDS/NewBooksCatalog.cs
@@ -97,13 +97,17 @@ namespace TinyOPDS.OPDS
             // Add page info to title
             if (paginatedResult.TotalPages > 1)
             {
-                string pageInfo = StringUtils.ApplyPluralForm(paginatedResult.TotalBooks, Localizer.Language,
-                    string.Format(" - {0} {1}/{2} ({3} {4})",
-                        Localizer.Text("Page"),
-                        pageNumber + 1,
-                        paginatedResult.TotalPages,
-                        paginatedResult.TotalBooks,
-                        Localizer.Text("books")));
+                 string booksInfo = StringUtils.ApplyPluralForm(
+                    paginatedResult.TotalBooks,
+                    Localizer.Language,
+                    string.Format(Localizer.Text("{0} books"), paginatedResult.TotalBooks)
+                );
+
+                string pageInfo = string.Format(" - {0} {1}/{2} ({3})",
+                    Localizer.Text("Page"),
+                    pageNumber + 1,
+                    paginatedResult.TotalPages,
+                    booksInfo);
 
                 doc.Root.Element("title").Value += pageInfo;
             }

--- a/TinyOPDS/Resources/translation.xml
+++ b/TinyOPDS/Resources/translation.xml
@@ -1732,6 +1732,15 @@
 			<text lang="fr">Rechercher</text>
 			<text lang="pl">Szukaj</text>
 		</property>
+		<property>
+			<text lang="en">Page</text>
+			<text lang="ru">Страница</text>
+			<text lang="uk">Сторінка</text>
+			<text lang="de">Seite</text>
+			<text lang="es">Page</text>
+			<text lang="fr">Página</text>
+			<text lang="pl">Strona</text>
+		</property>
 
 		<property>
 			<text lang="en">Table of Contents</text>


### PR DESCRIPTION
Before:
<img width="1280" height="80" alt="i26-before" src="https://github.com/user-attachments/assets/db2648e3-4268-4511-8968-982b2644b290" />

After:
<img width="1280" height="80" alt="i26-after" src="https://github.com/user-attachments/assets/9fe5080c-b200-4818-b55d-715f3b04d935" />
