### PR TITLE
Fixed log creation

### DIFF
--- a/TinyOPDS/Properties/AssemblyInfo.cs
+++ b/TinyOPDS/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.12.1.0")]
-[assembly: AssemblyFileVersion("3.12.1.0")]
+[assembly: AssemblyVersion("3.13.0.0")]
+[assembly: AssemblyFileVersion("3.13.0.0")]

--- a/TinyOPDSCLI/Properties/AssemblyInfo.cs
+++ b/TinyOPDSCLI/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.12.1.0")]
-[assembly: AssemblyFileVersion("3.12.1.0")]
+[assembly: AssemblyVersion("3.13.0.0")]
+[assembly: AssemblyFileVersion("3.13.0.0")]


### PR DESCRIPTION
**please note:** root is required to create log at /var/logs/tinyopds so you should run (logged as regular user) `sudo mono ./TinyOPDSCLI.exe`